### PR TITLE
docs: fix bundlephobia links

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ This project is licensed under the MIT License, see the `LICENSE.md` file for mo
 [npm-version-href]: https://npmjs.com/package/@todde.tv/gltf-type-toolkit
 [npm-downloads-src]: https://img.shields.io/npm/dm/@todde.tv/gltf-type-toolkit?style=flat&colorA=181818&colorB=26ab7a
 [npm-downloads-href]: https://npmjs.com/package/@todde.tv/gltf-type-toolkit
-[bundle-size-src]: https://img.shields.io/bundlephobia/minzip/toddeTV/gltf-type-toolkit?style=flat&colorA=181818&colorB=26ab7a
-[bundle-size-href]: https://bundlephobia.com/package/@toddeTV/gltf-type-toolkit
+[bundle-size-src]: https://img.shields.io/bundlephobia/minzip/@todde.tv/gltf-type-toolkit?style=flat&colorA=181818&colorB=26ab7a
+[bundle-size-href]: https://bundlephobia.com/package/@todde.tv/gltf-type-toolkit
 [license-src]: https://img.shields.io/github/license/toddeTV/gltf-type-toolkit?style=flat&colorA=181818&colorB=26ab7a
 [license-href]: https://github.com/toddeTV/gltf-type-toolkit/blob/main/LICENSE


### PR DESCRIPTION
Sadly, this still won't work:

![grafik](https://github.com/user-attachments/assets/e6180fa4-926e-443c-8a82-a14cc7245ae6)

The node errors are known: https://github.com/pastelsky/bundlephobia/issues/875

I think the alternative would be to completely remove those badges. As a build tool plugin it is not our duty to ship as few bytes as possible. If this was our goal we would need to publish individual packages for each build tool.