### PR TITLE
fix: prevent duplicate parsing of the same model

### DIFF
--- a/src/core/generate/templates/runtime.hbs
+++ b/src/core/generate/templates/runtime.hbs
@@ -23,6 +23,12 @@ export const {{name}} = {
   return {{identifiers.nodeName}};
 }
 
-async function loadModel() {
-  return await gltfLoader.loadAsync(gltfPath);
+let modelPromise;
+
+function loadModel() {
+  if (!modelPromise) {
+    modelPromise = gltfLoader.loadAsync(gltfPath);
+  }
+
+  return modelPromise;
 }


### PR DESCRIPTION
fix #33 

In that issue I assumed that models can be downloaded multiple times. This is not the case but the parsing inside `GLTFLoader` might be done multiple times. This PR fixes this problem by holding the result in memory.