### PR TITLE
fix: always build valid identifiers for model node names

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
   },
   "dependencies": {
     "@node-rs/xxhash": "~1.7.6",
+    "@sindresorhus/slugify": "2.2.1",
     "citty": "~0.1.6",
     "consola": "~3.4.0",
     "handlebars": "~4.7.8",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
   },
   "dependencies": {
     "@node-rs/xxhash": "~1.7.6",
-    "@sindresorhus/slugify": "2.2.1",
+    "@sindresorhus/slugify": "~2.2.1",
     "citty": "~0.1.6",
     "consola": "~3.4.0",
     "handlebars": "~4.7.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@rspack/core':
         specifier: ^1
         version: 1.2.2(@swc/helpers@0.5.15)
+      '@sindresorhus/slugify':
+        specifier: 2.2.1
+        version: 2.2.1
       astro:
         specifier: '*'
         version: 5.1.9(@types/node@22.10.9)(jiti@2.4.2)(rollup@4.31.0)(terser@5.37.0)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
@@ -115,7 +118,7 @@ importers:
         version: 6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       vite-plugin-inspect:
         specifier: ~10.1.0
-        version: 10.1.0(@nuxt/kit@3.15.2(magicast@0.3.5)(rollup@4.31.0))(vite@6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 10.1.0(vite@6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
 
 packages:
 
@@ -1327,6 +1330,14 @@ packages:
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
+
+  '@sindresorhus/slugify@2.2.1':
+    resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
+    engines: {node: '>=12'}
+
+  '@sindresorhus/transliterate@1.6.0':
+    resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
+    engines: {node: '>=12'}
 
   '@stylistic/eslint-plugin@2.13.0':
     resolution: {integrity: sha512-RnO1SaiCFHn666wNz2QfZEFxvmiNRqhzaMXHXxXXKt+MEP7aajlPxUSMIQpKAaJfverpovEYqjBOXDq6dDcaOQ==}
@@ -5782,6 +5793,15 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
+  '@sindresorhus/slugify@2.2.1':
+    dependencies:
+      '@sindresorhus/transliterate': 1.6.0
+      escape-string-regexp: 5.0.0
+
+  '@sindresorhus/transliterate@1.6.0':
+    dependencies:
+      escape-string-regexp: 5.0.0
+
   '@stylistic/eslint-plugin@2.13.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3)':
     dependencies:
       '@typescript-eslint/utils': 8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3)
@@ -9360,7 +9380,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-plugin-inspect@10.1.0(@nuxt/kit@3.15.2(magicast@0.3.5)(rollup@4.31.0))(vite@6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)):
+  vite-plugin-inspect@10.1.0(vite@6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)):
     dependencies:
       debug: 4.4.0
       error-stack-parser-es: 1.0.5
@@ -9368,8 +9388,6 @@ snapshots:
       picocolors: 1.1.1
       sirv: 3.0.0
       vite: 6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
-    optionalDependencies:
-      '@nuxt/kit': 3.15.2(magicast@0.3.5)(rollup@4.31.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         specifier: ^1
         version: 1.2.2(@swc/helpers@0.5.15)
       '@sindresorhus/slugify':
-        specifier: 2.2.1
+        specifier: ~2.2.1
         version: 2.2.1
       astro:
         specifier: '*'
@@ -118,7 +118,7 @@ importers:
         version: 6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
       vite-plugin-inspect:
         specifier: ~10.1.0
-        version: 10.1.0(vite@6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 10.1.0(@nuxt/kit@3.15.2(magicast@0.3.5)(rollup@4.31.0))(vite@6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0))
 
 packages:
 
@@ -9380,7 +9380,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-plugin-inspect@10.1.0(vite@6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)):
+  vite-plugin-inspect@10.1.0(@nuxt/kit@3.15.2(magicast@0.3.5)(rollup@4.31.0))(vite@6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)):
     dependencies:
       debug: 4.4.0
       error-stack-parser-es: 1.0.5
@@ -9388,6 +9388,8 @@ snapshots:
       picocolors: 1.1.1
       sirv: 3.0.0
       vite: 6.0.11(@types/node@22.10.9)(jiti@2.4.2)(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
+    optionalDependencies:
+      '@nuxt/kit': 3.15.2(magicast@0.3.5)(rollup@4.31.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -1,5 +1,6 @@
 import type { Object3D } from 'three'
 import type { GLTF } from 'three-stdlib'
+import slugify from '@sindresorhus/slugify'
 import { Imports } from './utils/imports.js'
 
 export interface GltfNode {
@@ -57,9 +58,11 @@ function collectNamedChildren(imports: Imports, obj: Object3D, parentNode: GltfN
 }
 
 function toValidIdentifier(name: string): string {
-  if (/^[a-z_]/i.test(name)) {
-    return name
+  name = slugify(name, { lowercase: false, separator: '_' })
+
+  if (!/^[a-z_]/i.test(name)) {
+    name = `_${name}`
   }
 
-  return `_${name}`
+  return name
 }

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -58,7 +58,10 @@ function collectNamedChildren(imports: Imports, obj: Object3D, parentNode: GltfN
 }
 
 function toValidIdentifier(name: string): string {
-  name = slugify(name, { lowercase: false, separator: '_' })
+  name = slugify(name, {
+    lowercase: false,
+    separator: '_',
+  })
 
   if (!/^[a-z_]/i.test(name)) {
     name = `_${name}`

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -23,7 +23,7 @@ export function analyzeGltfModel({ scenes }: Pick<GLTF, 'scenes'>): { imports: I
     const node: GltfNode = {
       children: [],
       index,
-      name: toValidIdentifier(`${scene.name}Scene`),
+      name: `${toValidIdentifier(scene.name)}Scene`,
       type: imports.addImport('three', scene.type, true),
     }
 


### PR DESCRIPTION
Before:

![grafik](https://github.com/user-attachments/assets/f0ec24d6-cf63-4fa3-bd6d-7b1503d402d9)


After:

![grafik](https://github.com/user-attachments/assets/c7eeef81-7011-4ae5-8a29-a59ca41cf04c)
